### PR TITLE
Adjust shape infer, add new mask logic to avoid segfaults

### DIFF
--- a/src/ragged_to_dense.cpp
+++ b/src/ragged_to_dense.cpp
@@ -103,7 +103,8 @@ bool RaggedToDense::evaluate(ov::TensorVector& outputs, const ov::TensorVector& 
     }
 
     auto out_elems = reinterpret_cast<char*>(outputs[0].data());
-    auto out_mask = outputs[1].data<char>();
+    // Mask may be unallocated when this op is used as an intermediate node with no consumers
+    auto out_mask = outputs[1] ? outputs[1].data<char>() : nullptr;
 
     auto out_elem_orig = out_elems;
     auto out_mask_orig = out_mask;
@@ -119,6 +120,12 @@ bool RaggedToDense::evaluate(ov::TensorVector& outputs, const ov::TensorVector& 
         }
     };
 
+    auto mask_fill = [&](char*& dst, size_t count, char value) {
+        if (dst) {
+            dst = std::fill_n(dst, count, value);
+        }
+    };
+
     if (pad_right) {
         for (size_t i = 0; i < nelems; ++i) {
             const size_t data_len = static_cast<size_t>(ends[i] - begins[i]);
@@ -129,9 +136,9 @@ bool RaggedToDense::evaluate(ov::TensorVector& outputs, const ov::TensorVector& 
             const auto end = begin + elem_size * inner_elems * target_len;
             out_elems = std::copy(begin, end, out_elems);
 
-            out_mask = std::fill_n(out_mask, target_len * inner_elems, char(1));
+            mask_fill(out_mask, target_len * inner_elems, char(1));
             if (target_len < target_dim) {
-                out_mask = std::fill_n(out_mask, (target_dim - target_len) * inner_elems, char(0));
+                mask_fill(out_mask, (target_dim - target_len) * inner_elems, char(0));
             }
 
             while (target_len < target_dim) {
@@ -154,12 +161,14 @@ bool RaggedToDense::evaluate(ov::TensorVector& outputs, const ov::TensorVector& 
             const auto end = begin + elem_size * inner_elems * target_len;
             out_elems = std::copy(begin, end, out_elems);
 
-            out_mask = std::fill_n(out_mask, pad_len * inner_elems, char(0));
-            out_mask = std::fill_n(out_mask, (target_dim - pad_len) * inner_elems, char(1));
+            mask_fill(out_mask, pad_len * inner_elems, char(0));
+            mask_fill(out_mask, (target_dim - pad_len) * inner_elems, char(1));
         }
     }
 
     OPENVINO_ASSERT(out_elems == out_elem_orig + outputs[0].get_byte_size());
-    OPENVINO_ASSERT(out_mask == out_mask_orig + outputs[1].get_byte_size());
+    if (out_mask) {
+        OPENVINO_ASSERT(out_mask == out_mask_orig + outputs[1].get_byte_size());
+    }
     return true;
 }

--- a/src/ragged_to_ragged.cpp
+++ b/src/ragged_to_ragged.cpp
@@ -19,8 +19,24 @@ void RaggedToRagged::validate_and_infer_types() {
     OPENVINO_ASSERT(rowids_type == element::i32, "Expected an i32 rowids tensor ragged representation.");
     OPENVINO_ASSERT(first_dim_size_type == element::i32, "Expected an i32 first dim size tensor ragged representation.");
 
-    set_output_type(0, get_input_element_type(0), PartialShape({ Dimension::dynamic() }));
-    set_output_type(1, get_input_element_type(0), PartialShape({ Dimension::dynamic() }));
+    // Check whether input 1 is a Constant node, otherwise fall back to the lower-bound tensor
+    PartialShape out_shape({ Dimension::dynamic() });
+    auto infer_from_int32_tensor = [&](const ov::Tensor& t) {
+        if (t && t.get_element_type() == element::i32 && t.get_size() >= 1) {
+            out_shape = PartialShape({ static_cast<Dimension::value_type>(t.data<const int32_t>()[0]) });
+        }
+    };
+    if (const auto* first_dim_const = dynamic_cast<const Constant*>(get_input_node_ptr(1))) {
+        auto vals = first_dim_const->cast_vector<int32_t>();
+        if (!vals.empty()) {
+            out_shape = PartialShape({ static_cast<Dimension::value_type>(vals[0]) });
+        }
+    } else {
+        infer_from_int32_tensor(get_input_tensor(1).get_lower_value());
+    }
+
+    set_output_type(0, get_input_element_type(0), out_shape);
+    set_output_type(1, get_input_element_type(0), out_shape);
 }
 
 

--- a/src/ragged_to_ragged.hpp
+++ b/src/ragged_to_ragged.hpp
@@ -38,4 +38,12 @@ public:
     bool has_evaluate() const override {
         return true;
     }
+
+    bool evaluate_lower(ov::TensorVector& output_values) const override {
+        return false;
+    }
+
+    bool evaluate_upper(ov::TensorVector& output_values) const override {
+        return false;
+    }
 };


### PR DESCRIPTION
 - `validate_and_infer_types` always reported fully dynamic output shape, causing following ops to go dynamic as well
with static shape now inferred, OpenVINO bound propagation would call `evaluate()`
 - on a still-dynamic descriptor, hitting a `same_scheme` assertion in `tensor.cpp`, which is the reason for overriding`evaluate_lower`/`evaluate_upper`
 - in evaluate, an output may not be allocated by CPU if it has no consumers, causing segfault during data access, mask is a solution to that